### PR TITLE
add middleware for jwt authentication

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,6 @@
 import express, { type Application } from "express";
 import { userRouter, songRouter , playlistRouter , agregarRouter } from "./components";
+import { notfoundResponse } from "./middleware";
 
 const app: Application = express();
 //Middleware
@@ -12,15 +13,8 @@ app.use("/api/v1/playlists", playlistRouter);
 app.use("/api/v1/song-playlist", agregarRouter);
 
 
+app.use(notfoundResponse)
 
-//hello world
-app.get("/",(req,res)=>{
-    res.json(
-        {
-            "Title": "Hola mundo"
-        }
-    );
-})
 
 
 export default app;

--- a/src/components/song-playlist/index.ts
+++ b/src/components/song-playlist/index.ts
@@ -1,8 +1,9 @@
 import { Router } from "express";
 import {agregarCancion} from "./controller";
+import { jwtAuthentication } from "../../middleware";
 
 const agregarRouter: Router = Router();
 
-agregarRouter.post("/", agregarCancion);
+agregarRouter.post("/",agregarCancion);
 
 export default agregarRouter;

--- a/src/components/song/index.ts
+++ b/src/components/song/index.ts
@@ -1,10 +1,10 @@
 import { Router } from "express";
 import { listarSong, crearSong, getIdSong, listarSongPrivate } from "./controller";
-
+import { jwtAuthentication } from "../../middleware";
 const songRouter: Router = Router();
 
 songRouter.get("/", listarSongPrivate, listarSong);
-songRouter.post("/", crearSong);
+songRouter.post("/", jwtAuthentication,crearSong);
 songRouter.get("/:id",getIdSong);
 
 export default songRouter;

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,0 +1,22 @@
+import { getBearerToken,verifyJwt } from "../components/user/utils/auth";
+import type { NextFunction, Request, Response } from "express";
+
+export const jwtAuthentication = async (req: Request, res: Response,next:NextFunction): Promise<any> => {
+    const authHeader: string = req.headers['authorization'] ?? "";
+    const token = getBearerToken(authHeader);
+    const payload  = verifyJwt(token);
+    console.log("MIDDLEWARE")
+    if (!payload) {
+        return res.status(403).json({
+            error: "no autorizado"
+        })
+    };
+    return next()
+};
+
+export const notfoundResponse = async (req: Request, res: Response,next:NextFunction): Promise<any> => {
+
+    return res.status(404).json({
+        message:"not found"
+    })
+};


### PR DESCRIPTION
# [Proyecto Unidad 7](https://github.com/JPCenz/restAPI-playlists-ExpressJS) - [Trello](https://trello.com/b/gSwQUaSf/project-unit-7-silabuz)

## Description

- Agrego el middleware que permite proteger las rutas que necesitan autenticacion.
 funcion se llama jwtAuthentication() ubicado en  ./src/middleware/
- Agrego un response 404 en caso que el cliente haga un request a rutas no implementadas  => notfoundResponse()

---
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
## How Has This Been Tested?

Hacer request a las rutas protegidas sin un Bearer token válido , el servidor responderá con un status 403 y un mensaje no autorizado
